### PR TITLE
Provide default `IntoFfi` impl for `*c_void`.

### DIFF
--- a/src/into_ffi.rs
+++ b/src/into_ffi.rs
@@ -15,7 +15,7 @@
  * limitations under the Licenses. */
 
 use crate::string::*;
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_void};
 use std::ptr;
 
 /// This trait is used to return types over the FFI. It essentially is a mapping between a type and
@@ -277,4 +277,11 @@ macro_rules! impl_into_ffi_for_pointer {
     )+}
 }
 
-impl_into_ffi_for_pointer![*mut i8, *const i8, *mut u8, *const u8];
+impl_into_ffi_for_pointer![
+    *mut i8,
+    *const i8,
+    *mut u8,
+    *const u8,
+    *mut c_void,
+    *const c_void
+];


### PR DESCRIPTION
The caller may have had some safety things to worry about when they
were obtaining the `*c_void`, but once they'd obtained one then we
can assume it's safe to send over the FFI.

This is in service of https://github.com/mozilla/uniffi-rs/pull/462
which currently hacks around it with a wrapper type.