### PR TITLE
Make the panic handling functionality public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ where
 {
     *out_error = ExternError::success();
     let res: thread::Result<(ExternError, R::Value)> = panic::catch_unwind(|| {
-        init_panic_handling_once();
+        ensure_panic_hook_is_setup();
         match callback() {
             Ok(v) => (ExternError::default(), v.into_ffi_value()),
             Err(e) => (e.into(), R::ffi_default()),
@@ -302,8 +302,9 @@ pub mod abort_on_panic {
     }
 }
 
+/// Initialize our panic handling hook to optionally log panics
 #[cfg(feature = "log_panics")]
-fn init_panic_handling_once() {
+pub fn ensure_panic_hook_is_setup() {
     use std::sync::Once;
     static INIT_BACKTRACES: Once = Once::new();
     INIT_BACKTRACES.call_once(move || {
@@ -332,8 +333,9 @@ fn init_panic_handling_once() {
     });
 }
 
+/// Initialize our panic handling hook to optionally log panics
 #[cfg(not(feature = "log_panics"))]
-fn init_panic_handling_once() {}
+pub fn ensure_panic_hook_is_setup() {}
 
 /// ByteBuffer is a struct that represents an array of bytes to be sent over the FFI boundaries.
 /// There are several cases when you might want to use this, but the primary one for us


### PR DESCRIPTION
I think I will need this for uniffi#460.  It seems reasonable that if
ffi-support is going to set the global panic handling hook, then it
should give other crates the opportunity to initialize it if they need
to.

Updated the name to something that hopefully describes the intent a bit
more.