### PR TITLE
Swap asserts in test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -628,12 +628,12 @@ mod test {
 
         let bb = ByteBuffer::new_with_size(0);
         assert_eq!(bb.as_slice(), &[]);
-        assert!(!bb.data.is_null());
+        assert!(bb.data.is_null());
         bb.destroy();
 
         let bb = ByteBuffer::from_vec(vec![]);
         assert_eq!(bb.as_slice(), &[]);
-        assert!(!bb.data.is_null());
+        assert!(bb.data.is_null());
         bb.destroy();
     }
 }


### PR DESCRIPTION
The last commit 0fdc22a8dfe3731be5fd39b311e4e4885219e26c changed how
`from_vec` works. It now returns a null pointer and length 0.
The tests didn't account for that.

----

CI broke with #9. This repository might lack the CircleCI hooks to show that state.